### PR TITLE
Changed token for checkout action in deploy-release.yml to bypass rules

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.ADMIN_TOKEN }}
+          token: ${{ secrets.REPO_CONTENT_WRITE_TOKEN }}
 
       - name: Bump dependencies
         run: |


### PR DESCRIPTION
This is a small PR to change a token in the deploy-release action, so that the action can commit and push updates to the repo as 'access-bot' bypassing protection rules. 