### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Set version tag
         id: set-version
@@ -167,7 +167,6 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.REPO_CONTENT_WRITE_TOKEN }}
-          fetch-tags: true
       
       - name: Import GPG settings
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0


### PR DESCRIPTION
- [x] Fixed repo checkout with 'fetch-depth=0, to fetch all tags and produce an accurate new tag
- [x] Not really part of this PR, but added `access-bot` with `write` role to this repo, so it doesn't get denied access.

Tested the creation and push of the proper tag in [this workflow run](https://github.com/ACCESS-NRI/access-ram-condaenv/actions/runs/11943777759)