### PR TITLE
Rearrange channel ordering for pre-release deployment

### DIFF
--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -176,7 +176,7 @@ jobs:
           echo -n "-c file://${{github.workspace}}/${dependency_repo}${{env.CHANNEL_SUFFIX}} "; done)
 
           cmd="micromamba install ${{steps.get-dependencies.outputs.dependency-names}} \
-          -c accessnri -c conda-forge -c coecms $channels -y"
+          $channels -c accessnri -c conda-forge -c coecms -y"
           echo "$cmd"
           eval "$cmd"
       


### PR DESCRIPTION
Fixes #16 

The pre-release deployment determines if there are recent PRs to the tool repos, and if so downloads the source for those versions and places them in a local channel for the conda deployment to pick up.

This didn't seem to be working, and the supposition is that the channel ordering means that if there is a version in the `accessnri` conda channel that will be found and used.

This PR changes the ordering of the channels to ensure the cached versions in the local channel are located first.